### PR TITLE
Feature/removing winston

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
-      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
+      "version": "10.12.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
+      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
       "dev": true
     },
     "@types/sinon": {
@@ -58,15 +58,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.1.tgz",
       "integrity": "sha512-DK4YtH30I67k4klURIBS4VAe1aBISfS9lgNlHFkibSmKem2tLQc5VkKoJreT3dCJAd+xRyCS8bx1o97iq3yUVg==",
       "dev": true
-    },
-    "@types/winston": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
-      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "10.1.2"
-      }
     },
     "abbrev": {
       "version": "1.0.9",
@@ -139,7 +130,8 @@
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -461,11 +453,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
     "commander": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
@@ -516,11 +503,6 @@
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "date-fns": {
       "version": "1.29.0",
@@ -653,11 +635,6 @@
         "iconv-lite": "0.4.23",
         "tmp": "0.0.33"
       }
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -993,11 +970,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -4629,11 +4601,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "streamroller": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.4.1.tgz",
@@ -5257,19 +5224,6 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
-    },
-    "winston": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
-      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
-      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-logger",
-  "version": "0.1.5",
+  "version": "0.2.0-develop.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,14 +54,12 @@
       "email": "rjdavis@channelape.com"
     }
   ],
-  "dependencies": {
-    "winston": "2.4.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/chai": "4.1.3",
     "@types/mocha": "5.2.0",
+    "@types/node": "^10.12.9",
     "@types/sinon": "4.3.1",
-    "@types/winston": "^2.3.9",
     "chai": "4.1.2",
     "concurrently": "3.5.1",
     "istanbul": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-logger",
-  "version": "0.1.6",
+  "version": "0.2.0-develop.0",
   "description": "Common logger for all ChannelApe TypeScript and JavaScript projects.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,3 +1,5 @@
+import { EOL } from 'os';
+
 import LogLevel from '../model/LogLevel';
 
 export default class Logger {
@@ -67,7 +69,7 @@ export default class Logger {
     const now = new Date();
     const timestamp = getTimeStamp(now);
     const level = messageLogLevel.toUpperCase();
-    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}\r\n`;
+    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}${EOL}`;
 
     function getTimeStamp(date: Date): string {
       const yyyMmDd = `${date.getFullYear()}-${getMonth(date)}-${getDay(date)}`;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -8,18 +8,25 @@ export default class Logger {
   }
 
   public error(log: string): void {
-    process.stdout.emit(this.formatLog(log));
+    this.log(LogLevel.ERROR, log);
   }
 
   public warn(log: string): void {
-    process.stdout.emit(this.formatLog(log));
+    this.log(LogLevel.WARN, log);
   }
 
   public info(log: string): void {
-    process.stdout.emit(this.formatLog(log));
+    this.log(LogLevel.INFO, log);
   }
 
   public debug(log: string): void {
+    this.log(LogLevel.DEBUG, log);
+  }
+
+  private log(logLevel: LogLevel, log: string): void {
+    if (this.logLevel === LogLevel.OFF) {
+      return;
+    }
     process.stdout.emit(this.formatLog(log));
   }
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -34,7 +34,10 @@ export default class Logger {
   }
 
   private determineIfLogShouldBeEmitted(logLevel: LogLevel): boolean {
-    if (this.logLevel === LogLevel.VERBOSE || this.logLevel === LogLevel.DEBUG) {
+    if (this.logLevel === LogLevel.DEBUG) {
+      return true;
+    }
+    if (this.logLevel === LogLevel.VERBOSE && logLevel !== LogLevel.DEBUG) {
       return true;
     }
     if (this.logLevel === LogLevel.INFO &&

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,32 +1,26 @@
-import * as util from 'util';
-import * as winston from 'winston';
 import LogLevel from '../model/LogLevel';
 
-const LOG_FORMAT = '%s - %s';
-
 export default class Logger {
-  private readonly logger: winston.LoggerInstance;
   private readonly logLevel: LogLevel;
 
   constructor(private readonly loggerName: string, logLevel: LogLevel | string) {
     this.logLevel = this.getLogLevel(logLevel);
-    this.logger = this.createLogger();
   }
 
   public error(log: string): void {
-    this.logger.error(util.format(LOG_FORMAT, this.loggerName, log));
+    process.stdout.emit(this.logFormatter(log));
   }
 
   public warn(log: string): void {
-    this.logger.warn(util.format(LOG_FORMAT, this.loggerName, log));
+    process.stdout.emit(this.logFormatter(log));
   }
 
   public info(log: string): void {
-    this.logger.info(util.format(LOG_FORMAT, this.loggerName, log));
+    process.stdout.emit(this.logFormatter(log));
   }
 
   public debug(log: string): void {
-    this.logger.debug(util.format(LOG_FORMAT, this.loggerName, log));
+    process.stdout.emit(this.logFormatter(log));
   }
 
   private getLogLevel(logLevel: LogLevel | string): LogLevel {
@@ -39,18 +33,11 @@ export default class Logger {
     return LogLevel.INFO;
   }
 
-  private createLogger() {
-    return new winston.Logger({
-      transports: [new winston.transports.Console({ formatter: this.logFormatter })],
-      level: this.logLevel
-    });
-  }
-
-  private logFormatter(options: any): string {
+  private logFormatter(message: string): string {
     const now = new Date();
     const timestamp = getTimeStamp(now);
-    const level = options.level.toUpperCase();
-    return `[${timestamp}] [${level}] ${options.message}`;
+    const level = this.logLevel.toUpperCase();
+    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}`;
 
     function getTimeStamp(date: Date): string {
       const yyyMmDd = `${date.getFullYear()}-${getMonth(date)}-${getDay(date)}`;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,5 +1,3 @@
-import { EOL } from 'os';
-
 import LogLevel from '../model/LogLevel';
 
 export default class Logger {
@@ -28,9 +26,9 @@ export default class Logger {
   private log(logLevel: LogLevel, log: string): void {
     if (this.determineIfLogShouldBeEmitted(logLevel)) {
       if (logLevel === LogLevel.DEBUG || logLevel === LogLevel.ERROR) {
-        process.stderr.write(this.formatLog(log, logLevel));
+        console.error(this.formatLog(log, logLevel));
       } else {
-        process.stdout.write(this.formatLog(log, logLevel));
+        console.log(this.formatLog(log, logLevel));
       }
     }
   }
@@ -69,7 +67,7 @@ export default class Logger {
     const now = new Date();
     const timestamp = getTimeStamp(now);
     const level = messageLogLevel.toUpperCase();
-    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}${EOL}`;
+    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}`;
 
     function getTimeStamp(date: Date): string {
       const yyyMmDd = `${date.getFullYear()}-${getMonth(date)}-${getDay(date)}`;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -25,7 +25,7 @@ export default class Logger {
 
   private log(logLevel: LogLevel, log: string): void {
     if (this.determineIfLogShouldBeEmitted(logLevel)) {
-      process.stdout.write(this.formatLog(log));
+      process.stdout.write(this.formatLog(log, logLevel));
     }
   }
 
@@ -56,10 +56,10 @@ export default class Logger {
     return LogLevel.INFO;
   }
 
-  private formatLog(message: string): string {
+  private formatLog(message: string, messageLogLevel: LogLevel): string {
     const now = new Date();
     const timestamp = getTimeStamp(now);
-    const level = this.logLevel.toUpperCase();
+    const level = messageLogLevel.toUpperCase();
     return `[${timestamp}] [${level}] ${this.loggerName} - ${message}`;
 
     function getTimeStamp(date: Date): string {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -8,19 +8,19 @@ export default class Logger {
   }
 
   public error(log: string): void {
-    process.stdout.emit(this.logFormatter(log));
+    process.stdout.emit(this.formatLog(log));
   }
 
   public warn(log: string): void {
-    process.stdout.emit(this.logFormatter(log));
+    process.stdout.emit(this.formatLog(log));
   }
 
   public info(log: string): void {
-    process.stdout.emit(this.logFormatter(log));
+    process.stdout.emit(this.formatLog(log));
   }
 
   public debug(log: string): void {
-    process.stdout.emit(this.logFormatter(log));
+    process.stdout.emit(this.formatLog(log));
   }
 
   private getLogLevel(logLevel: LogLevel | string): LogLevel {
@@ -33,7 +33,7 @@ export default class Logger {
     return LogLevel.INFO;
   }
 
-  private logFormatter(message: string): string {
+  private formatLog(message: string): string {
     const now = new Date();
     const timestamp = getTimeStamp(now);
     const level = this.logLevel.toUpperCase();

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -25,7 +25,7 @@ export default class Logger {
 
   private log(logLevel: LogLevel, log: string): void {
     if (this.determineIfLogShouldBeEmitted(logLevel)) {
-      process.stdout.emit(this.formatLog(log));
+      process.stdout.write(this.formatLog(log));
     }
   }
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -60,7 +60,7 @@ export default class Logger {
     const now = new Date();
     const timestamp = getTimeStamp(now);
     const level = messageLogLevel.toUpperCase();
-    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}`;
+    return `[${timestamp}] [${level}] ${this.loggerName} - ${message}\r\n`;
 
     function getTimeStamp(date: Date): string {
       const yyyMmDd = `${date.getFullYear()}-${getMonth(date)}-${getDay(date)}`;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -24,10 +24,26 @@ export default class Logger {
   }
 
   private log(logLevel: LogLevel, log: string): void {
-    if (this.logLevel === LogLevel.OFF) {
-      return;
+    if (this.determineIfLogShouldBeEmitted(logLevel)) {
+      process.stdout.emit(this.formatLog(log));
     }
-    process.stdout.emit(this.formatLog(log));
+  }
+
+  private determineIfLogShouldBeEmitted(logLevel: LogLevel): boolean {
+    if (this.logLevel === LogLevel.VERBOSE || this.logLevel === LogLevel.DEBUG) {
+      return true;
+    }
+    if (this.logLevel === LogLevel.INFO &&
+        (logLevel === LogLevel.INFO || logLevel === LogLevel.WARN || logLevel === LogLevel.ERROR)) {
+      return true;
+    }
+    if (this.logLevel === LogLevel.WARN && (logLevel === LogLevel.WARN || logLevel === LogLevel.ERROR)) {
+      return true;
+    }
+    if (this.logLevel === LogLevel.ERROR && logLevel === LogLevel.ERROR) {
+      return true;
+    }
+    return false;
   }
 
   private getLogLevel(logLevel: LogLevel | string): LogLevel {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -25,7 +25,11 @@ export default class Logger {
 
   private log(logLevel: LogLevel, log: string): void {
     if (this.determineIfLogShouldBeEmitted(logLevel)) {
-      process.stdout.write(this.formatLog(log, logLevel));
+      if (logLevel === LogLevel.DEBUG || logLevel === LogLevel.ERROR) {
+        process.stderr.write(this.formatLog(log, logLevel));
+      } else {
+        process.stdout.write(this.formatLog(log, logLevel));
+      }
     }
   }
 

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
     testFramework: "mocha",
     coverageAnalysis: "off",
     tsconfigFile: "tsconfig.json",
-    thresholds: { high: 90, low: 70, break: 91 },
+    thresholds: { high: 100, low: 90, break: 98 },
     mutate: [
       "src/**/*.ts",
       "!src/types/*d.ts"

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -29,6 +29,11 @@ describe('Logger', () => {
     done();
   });
 
+  it('constructor should create winston logger with LogLevel of INFO when sent an invalid LogLevel string', () => {
+    logger = new Logger('name', 'INVALID_LOG_LEVEL_VALUE');
+    assertThatOnlyInfoLevelLogsAndAboveAreCalled(logger);
+  });
+
   it('constructor should create winston logger with correct LogLevel when sent a LogLevel string', () => {
     logger = new Logger('name', 'ERROR');
     logger.error('This error is being reported by a logger with a string for a LogLevel');
@@ -135,6 +140,10 @@ describe('Logger', () => {
 
   it('only error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
     logger = new Logger('LogName', LogLevel.INFO);
+    assertThatOnlyInfoLevelLogsAndAboveAreCalled(logger);
+  });
+
+  function assertThatOnlyInfoLevelLogsAndAboveAreCalled(logger: Logger): void {
     logger.error('error message');
     expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
@@ -143,5 +152,5 @@ describe('Logger', () => {
     expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
     expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
-  });
+  }
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -62,4 +62,16 @@ describe('Logger', () => {
     const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message';
     expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
+
+  it('no logs should be emitted when when logLevel is OFF', () => {
+    logger = new Logger('LogName', LogLevel.OFF);
+    logger.error('error message');
+    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
+    logger.warn('warn message');
+    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
+    logger.info('info message');
+    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
+    logger.debug('debug message');
+    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
+  });
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -111,7 +111,7 @@ describe('Logger', () => {
     expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
   });
 
-  it('error and warn level logs should be emitted when when logLevel is WARN', () => {
+  it('only error and warn level logs should be emitted when when logLevel is WARN', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.error('error message');
     expect(stdoutSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
@@ -123,7 +123,7 @@ describe('Logger', () => {
     expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
   });
 
-  it('error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
+  it('only error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.error('error message');
     expect(stdoutSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -89,13 +89,21 @@ describe('Logger', () => {
 
   it('all logs should be emitted when when logLevel is DEBUG', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
+
     logger.error('error message');
+    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message');
     expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+
     logger.warn('warn message');
     expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message');
+
     logger.info('info message');
+    expect(stdoutWriteSpy.args[2][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message');
     expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
+
     logger.debug('debug message');
+    expect(stdoutWriteSpy.args[3][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message');
     expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
   });
 

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { EOL } from 'os';
 import LogLevel from '../../src/model/LogLevel';
 import Logger from '../../src/utils/Logger';
 
@@ -8,8 +7,8 @@ describe('Logger', () => {
 
   let logger: Logger;
   let sandbox: sinon.SinonSandbox;
-  let stdoutWriteSpy: sinon.SinonSpy;
-  let stderrWriteSpy: sinon.SinonSpy;
+  let consoleLogSpy: sinon.SinonSpy;
+  let consoleErrorSpy: sinon.SinonSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -20,8 +19,8 @@ describe('Logger', () => {
     sandbox.stub(Date.prototype, 'getMinutes').returns(9);
     sandbox.stub(Date.prototype, 'getSeconds').returns(5);
     sandbox.stub(Date.prototype, 'getMilliseconds').returns(8);
-    stdoutWriteSpy = sandbox.spy(process.stdout, 'write');
-    stderrWriteSpy = sandbox.spy(process.stderr, 'write');
+    consoleLogSpy = sandbox.spy(console, 'log');
+    consoleErrorSpy = sandbox.spy(console, 'error');
     done();
   });
 
@@ -39,76 +38,76 @@ describe('Logger', () => {
     logger = new Logger('name', 'ERROR');
     logger.error('This error is being reported by a logger with a string for a LogLevel');
     const expectedMessage =
-`[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel${EOL}`;
-    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
+`[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel`;
+    expect(consoleErrorSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('no logs should be emitted when when logLevel is OFF', () => {
     logger = new Logger('LogName', LogLevel.OFF);
     logger.error('error message');
-    expect(stderrWriteSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
+    expect(consoleErrorSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
+    expect(consoleLogSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
     logger.info('info message');
-    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
+    expect(consoleLogSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
     logger.debug('debug message');
-    expect(stderrWriteSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
+    expect(consoleErrorSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
   });
 
   it('only error, warn, and info level logs should be emitted when when logLevel is VERBOSE', () => {
     logger = new Logger('LogName', LogLevel.VERBOSE);
     logger.error('error message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
   });
 
   it('all logs should be emitted when when logLevel is DEBUG', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
 
     logger.error('error message');
-    expect(stderrWriteSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [ERROR] LogName - error message${EOL}`);
-    expect(stderrWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(consoleErrorSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [ERROR] LogName - error message`);
+    expect(consoleErrorSpy.callCount).to.equal(1, 'All logs should have been emitted');
 
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
-    expect(stdoutWriteSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [WARN] LogName - warn message${EOL}`);
+    expect(consoleLogSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(consoleLogSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [WARN] LogName - warn message`);
 
     logger.info('info message');
-    expect(stdoutWriteSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [INFO] LogName - info message${EOL}`);
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(consoleLogSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [INFO] LogName - info message`);
+    expect(consoleLogSpy.callCount).to.equal(2, 'All logs should have been emitted');
 
     logger.debug('debug message');
-    expect(stderrWriteSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message${EOL}`);
-    expect(stderrWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(consoleErrorSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message`);
+    expect(consoleErrorSpy.callCount).to.equal(2, 'All logs should have been emitted');
   });
 
   it('only error level logs should be emitted when when logLevel is ERROR', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(0, 'only error level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(0, 'only error level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(0, 'only error level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(0, 'only error level logs should be emitted');
     logger.debug('debug message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error level logs should be emitted');
   });
 
   it('only error and warn level logs should be emitted when when logLevel is WARN', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.error('error message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.debug('debug message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
   });
 
   it('only error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
@@ -118,12 +117,12 @@ describe('Logger', () => {
 
   function assertThatOnlyInfoLevelLogsAndAboveAreCalled(logger: Logger): void {
     logger.error('error message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
+    expect(consoleLogSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
   }
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -31,35 +31,35 @@ describe('Logger', () => {
     logger = new Logger('name', 'ERROR');
     logger.error('This error is being reported by a logger with a string for a LogLevel');
     const expectedMessage =
-      '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel';
+  '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel\r\n';
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('error() should log when logLevel is ERROR or above', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message';
+    const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n';
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('warn() should log when logLevel is WARN or above', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.warn('warn message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [WARN] LogName - warn message';
+    const expectedMessage = '[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n';
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('info() should log when logLevel is INFO or above', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.info('info message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [INFO] LogName - info message';
+    const expectedMessage = '[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n';
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('debug() should log when logLevel is DEBUG or above', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
     logger.debug('debug message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message';
+    const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n';
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
@@ -91,19 +91,19 @@ describe('Logger', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
 
     logger.error('error message');
-    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message');
+    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n');
     expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
 
     logger.warn('warn message');
     expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
-    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message');
+    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n');
 
     logger.info('info message');
-    expect(stdoutWriteSpy.args[2][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message');
+    expect(stdoutWriteSpy.args[2][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n');
     expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
 
     logger.debug('debug message');
-    expect(stdoutWriteSpy.args[3][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message');
+    expect(stdoutWriteSpy.args[3][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n');
     expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
   });
 

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -43,34 +43,6 @@ describe('Logger', () => {
     expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
-  it('error() should log when logLevel is ERROR or above', () => {
-    logger = new Logger('LogName', LogLevel.ERROR);
-    logger.error('error message');
-    const expectedMessage = `[1984-05-07 03:09:05.008] [ERROR] LogName - error message${EOL}`;
-    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
-  });
-
-  it('warn() should log when logLevel is WARN or above', () => {
-    logger = new Logger('LogName', LogLevel.WARN);
-    logger.warn('warn message');
-    const expectedMessage = `[1984-05-07 03:09:05.008] [WARN] LogName - warn message${EOL}`;
-    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
-  });
-
-  it('info() should log when logLevel is INFO or above', () => {
-    logger = new Logger('LogName', LogLevel.INFO);
-    logger.info('info message');
-    const expectedMessage = `[1984-05-07 03:09:05.008] [INFO] LogName - info message${EOL}`;
-    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
-  });
-
-  it('debug() should log when logLevel is DEBUG or above', () => {
-    logger = new Logger('LogName', LogLevel.DEBUG);
-    logger.debug('debug message');
-    const expectedMessage = `[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message${EOL}`;
-    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
-  });
-
   it('no logs should be emitted when when logLevel is OFF', () => {
     logger = new Logger('LogName', LogLevel.OFF);
     logger.error('error message');

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import { EOL } from 'os';
 import LogLevel from '../../src/model/LogLevel';
 import Logger from '../../src/utils/Logger';
 
@@ -38,35 +39,35 @@ describe('Logger', () => {
     logger = new Logger('name', 'ERROR');
     logger.error('This error is being reported by a logger with a string for a LogLevel');
     const expectedMessage =
-  '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel\r\n';
+`[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel${EOL}`;
     expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('error() should log when logLevel is ERROR or above', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n';
+    const expectedMessage = `[1984-05-07 03:09:05.008] [ERROR] LogName - error message${EOL}`;
     expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('warn() should log when logLevel is WARN or above', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.warn('warn message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n';
+    const expectedMessage = `[1984-05-07 03:09:05.008] [WARN] LogName - warn message${EOL}`;
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('info() should log when logLevel is INFO or above', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.info('info message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n';
+    const expectedMessage = `[1984-05-07 03:09:05.008] [INFO] LogName - info message${EOL}`;
     expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('debug() should log when logLevel is DEBUG or above', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
     logger.debug('debug message');
-    const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n';
+    const expectedMessage = `[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message${EOL}`;
     expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
@@ -98,19 +99,19 @@ describe('Logger', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
 
     logger.error('error message');
-    expect(stderrWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n');
+    expect(stderrWriteSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [ERROR] LogName - error message${EOL}`);
     expect(stderrWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
 
     logger.warn('warn message');
     expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
-    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n');
+    expect(stdoutWriteSpy.args[0][0]).to.equal(`[1984-05-07 03:09:05.008] [WARN] LogName - warn message${EOL}`);
 
     logger.info('info message');
-    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n');
+    expect(stdoutWriteSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [INFO] LogName - info message${EOL}`);
     expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
 
     logger.debug('debug message');
-    expect(stderrWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n');
+    expect(stderrWriteSpy.args[1][0]).to.equal(`[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message${EOL}`);
     expect(stderrWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
   });
 

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -74,4 +74,64 @@ describe('Logger', () => {
     logger.debug('debug message');
     expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
   });
+
+  it('all logs should be emitted when when logLevel is VERBOSE', () => {
+    logger = new Logger('LogName', LogLevel.VERBOSE);
+    logger.error('error message');
+    expect(stdoutSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    logger.warn('warn message');
+    expect(stdoutSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    logger.info('info message');
+    expect(stdoutSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    logger.debug('debug message');
+    expect(stdoutSpy.callCount).to.equal(4, 'All logs should have been emitted');
+  });
+
+  it('all logs should be emitted when when logLevel is DEBUG', () => {
+    logger = new Logger('LogName', LogLevel.DEBUG);
+    logger.error('error message');
+    expect(stdoutSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    logger.warn('warn message');
+    expect(stdoutSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    logger.info('info message');
+    expect(stdoutSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    logger.debug('debug message');
+    expect(stdoutSpy.callCount).to.equal(4, 'All logs should have been emitted');
+  });
+
+  it('only error level logs should be emitted when when logLevel is ERROR', () => {
+    logger = new Logger('LogName', LogLevel.ERROR);
+    logger.error('error message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    logger.warn('warn message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    logger.info('info message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    logger.debug('debug message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+  });
+
+  it('error and warn level logs should be emitted when when logLevel is WARN', () => {
+    logger = new Logger('LogName', LogLevel.WARN);
+    logger.error('error message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    logger.warn('warn message');
+    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    logger.info('info message');
+    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    logger.debug('debug message');
+    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+  });
+
+  it('error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
+    logger = new Logger('LogName', LogLevel.INFO);
+    logger.error('error message');
+    expect(stdoutSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    logger.warn('warn message');
+    expect(stdoutSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
+    logger.info('info message');
+    expect(stdoutSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+    logger.debug('debug message');
+    expect(stdoutSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+  });
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -82,16 +82,16 @@ describe('Logger', () => {
     expect(stderrWriteSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
   });
 
-  it('all logs should be emitted when when logLevel is VERBOSE', () => {
+  it('only error, warn, and info level logs should be emitted when when logLevel is VERBOSE', () => {
     logger = new Logger('LogName', LogLevel.VERBOSE);
     logger.error('error message');
-    expect(stderrWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
-    expect(stderrWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
   });
 
   it('all logs should be emitted when when logLevel is DEBUG', () => {

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -7,7 +7,7 @@ describe('Logger', () => {
 
   let logger: Logger;
   let sandbox: sinon.SinonSandbox;
-  let stdoutSpy: sinon.SinonSpy;
+  let stdoutWriteSpy: sinon.SinonSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -18,7 +18,7 @@ describe('Logger', () => {
     sandbox.stub(Date.prototype, 'getMinutes').returns(9);
     sandbox.stub(Date.prototype, 'getSeconds').returns(5);
     sandbox.stub(Date.prototype, 'getMilliseconds').returns(8);
-    stdoutSpy = sandbox.spy(process.stdout, 'emit');
+    stdoutWriteSpy = sandbox.spy(process.stdout, 'write');
     done();
   });
 
@@ -32,106 +32,106 @@ describe('Logger', () => {
     logger.error('This error is being reported by a logger with a string for a LogLevel');
     const expectedMessage =
       '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel';
-    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('error() should log when logLevel is ERROR or above', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message';
-    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('warn() should log when logLevel is WARN or above', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.warn('warn message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [WARN] LogName - warn message';
-    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('info() should log when logLevel is INFO or above', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.info('info message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [INFO] LogName - info message';
-    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('debug() should log when logLevel is DEBUG or above', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
     logger.debug('debug message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message';
-    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('no logs should be emitted when when logLevel is OFF', () => {
     logger = new Logger('LogName', LogLevel.OFF);
     logger.error('error message');
-    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
+    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
     logger.warn('warn message');
-    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
+    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
     logger.info('info message');
-    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
+    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
     logger.debug('debug message');
-    expect(stdoutSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
+    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
   });
 
   it('all logs should be emitted when when logLevel is VERBOSE', () => {
     logger = new Logger('LogName', LogLevel.VERBOSE);
     logger.error('error message');
-    expect(stdoutSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
     logger.warn('warn message');
-    expect(stdoutSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
     logger.info('info message');
-    expect(stdoutSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
     logger.debug('debug message');
-    expect(stdoutSpy.callCount).to.equal(4, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
   });
 
   it('all logs should be emitted when when logLevel is DEBUG', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
     logger.error('error message');
-    expect(stdoutSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
     logger.warn('warn message');
-    expect(stdoutSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
     logger.info('info message');
-    expect(stdoutSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
     logger.debug('debug message');
-    expect(stdoutSpy.callCount).to.equal(4, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
   });
 
   it('only error level logs should be emitted when when logLevel is ERROR', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
     logger.info('info message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
   });
 
   it('only error and warn level logs should be emitted when when logLevel is WARN', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.error('error message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
     logger.info('info message');
-    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
   });
 
   it('only error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.error('error message');
-    expect(stdoutSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.info('info message');
-    expect(stdoutSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
   });
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import * as winston from 'winston';
 import LogLevel from '../../src/model/LogLevel';
 import Logger from '../../src/utils/Logger';
 
@@ -8,8 +7,7 @@ describe('Logger', () => {
 
   let logger: Logger;
   let sandbox: sinon.SinonSandbox;
-  let winstonStub: sinon.SinonStub;
-  let fakeWinston: any;
+  let stdoutSpy: sinon.SinonSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -20,13 +18,7 @@ describe('Logger', () => {
     sandbox.stub(Date.prototype, 'getMinutes').returns(9);
     sandbox.stub(Date.prototype, 'getSeconds').returns(5);
     sandbox.stub(Date.prototype, 'getMilliseconds').returns(8);
-    fakeWinston = {
-      error: sinon.spy(),
-      warn: sinon.spy(),
-      info: sinon.spy(),
-      debug: sinon.spy()
-    };
-    winstonStub = sandbox.stub(winston, 'Logger').returns(fakeWinston);
+    stdoutSpy = sandbox.spy(process.stdout, 'emit');
     done();
   });
 
@@ -35,93 +27,39 @@ describe('Logger', () => {
     done();
   });
 
-  it('should format the date correctly based on local time', () => {
-    const options = {
-      message: 'message',
-      level: 'error'
-    };
-    logger = new Logger('LogName', LogLevel.VERBOSE);
-    const expectedErrorMessage = '[1984-05-07 03:09:05.008] [ERROR] message';
-    expect(winstonStub.args[0][0].transports[0].formatter(options)).to.equal(expectedErrorMessage);
-  });
-
   it('constructor should create winston logger with correct LogLevel when sent a LogLevel string', () => {
-    logger = new Logger('LogName', 'ERROR');
+    logger = new Logger('name', 'ERROR');
     logger.error('This error is being reported by a logger with a string for a LogLevel');
-    const expectedMessage = 'LogName - This error is being reported by a logger with a string for a LogLevel';
-    expect(fakeWinston.error.called).to.be.true;
-    expect(fakeWinston.error.args[0][0]).to.equal(expectedMessage);
-  });
-
-  it('constructor should create winston logger given LogLevel', () => {
-    logger = new Logger('LogName', LogLevel.ERROR);
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.ERROR);
-  });
-
-  it('constructor should create winston logger with default LogLevel if a bad string is passed in as LogLevel', () => {
-    logger = new Logger('LogName', 'NOT_AN_ACTUAL_LEVEL');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.INFO);
-  });
-
-  it('constructor should create winston logger with LogLevel of "OFF" when given the string "OFF"', () => {
-    logger = new Logger('LogName', 'OFF');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.OFF);
-  });
-
-  it('constructor should create winston logger with LogLevel of "ERROR" when given the string "ERROR"', () => {
-    logger = new Logger('LogName', 'ERROR');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.ERROR);
-  });
-
-  it('constructor should create winston logger with LogLevel of "WARN" when given the string "WARN"', () => {
-    logger = new Logger('LogName', 'WARN');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.WARN);
-  });
-
-  it('constructor should create winston logger with LogLevel of "INFO" when given the string "INFO"', () => {
-    logger = new Logger('LogName', 'INFO');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.INFO);
-  });
-
-  it('constructor should create winston logger with LogLevel of "VERBOSE" when given the string "VERBOSE"', () => {
-    logger = new Logger('LogName', 'VERBOSE');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.VERBOSE);
-  });
-
-  it('constructor should create winston logger with LogLevel of "DEBUG" when given the string "DEBUG"', () => {
-    logger = new Logger('LogName', 'DEBUG');
-    expect(winstonStub.args[0][0].level).to.equal(LogLevel.DEBUG);
+    const expectedMessage =
+      '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel';
+    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('error() should log when logLevel is ERROR or above', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
-    logger.error('ERROR');
-    const expectedMessage = 'LogName - ERROR';
-    expect(fakeWinston.error.called).to.be.true;
-    expect(fakeWinston.error.args[0][0]).to.equal(expectedMessage);
+    logger.error('error message');
+    const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message';
+    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('warn() should log when logLevel is WARN or above', () => {
     logger = new Logger('LogName', LogLevel.WARN);
-    logger.warn('WARN');
-    const expectedMessage = 'LogName - WARN';
-    expect(fakeWinston.warn.called).to.be.true;
-    expect(fakeWinston.warn.args[0][0]).to.equal(expectedMessage);
+    logger.warn('warn message');
+    const expectedMessage = '[1984-05-07 03:09:05.008] [WARN] LogName - warn message';
+    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('info() should log when logLevel is INFO or above', () => {
     logger = new Logger('LogName', LogLevel.INFO);
-    logger.info('INFO');
-    const expectedMessage = 'LogName - INFO';
-    expect(fakeWinston.info.called).to.be.true;
-    expect(fakeWinston.info.args[0][0]).to.equal(expectedMessage);
+    logger.info('info message');
+    const expectedMessage = '[1984-05-07 03:09:05.008] [INFO] LogName - info message';
+    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('debug() should log when logLevel is DEBUG or above', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
-    logger.debug('DEBUG');
-    const expectedMessage = 'LogName - DEBUG';
-    expect(fakeWinston.debug.called).to.be.true;
-    expect(fakeWinston.debug.args[0][0]).to.equal(expectedMessage);
+    logger.debug('debug message');
+    const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message';
+    expect(stdoutSpy.args[0][0]).to.equal(expectedMessage);
   });
 });

--- a/test/utils/Logger.spec.ts
+++ b/test/utils/Logger.spec.ts
@@ -8,6 +8,7 @@ describe('Logger', () => {
   let logger: Logger;
   let sandbox: sinon.SinonSandbox;
   let stdoutWriteSpy: sinon.SinonSpy;
+  let stderrWriteSpy: sinon.SinonSpy;
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -19,6 +20,7 @@ describe('Logger', () => {
     sandbox.stub(Date.prototype, 'getSeconds').returns(5);
     sandbox.stub(Date.prototype, 'getMilliseconds').returns(8);
     stdoutWriteSpy = sandbox.spy(process.stdout, 'write');
+    stderrWriteSpy = sandbox.spy(process.stderr, 'write');
     done();
   });
 
@@ -32,14 +34,14 @@ describe('Logger', () => {
     logger.error('This error is being reported by a logger with a string for a LogLevel');
     const expectedMessage =
   '[1984-05-07 03:09:05.008] [ERROR] name - This error is being reported by a logger with a string for a LogLevel\r\n';
-    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('error() should log when logLevel is ERROR or above', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n';
-    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('warn() should log when logLevel is WARN or above', () => {
@@ -60,86 +62,86 @@ describe('Logger', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
     logger.debug('debug message');
     const expectedMessage = '[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n';
-    expect(stdoutWriteSpy.args[0][0]).to.equal(expectedMessage);
+    expect(stderrWriteSpy.args[0][0]).to.equal(expectedMessage);
   });
 
   it('no logs should be emitted when when logLevel is OFF', () => {
     logger = new Logger('LogName', LogLevel.OFF);
     logger.error('error message');
-    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
+    expect(stderrWriteSpy.called).to.equal(false, 'No logs should have been emitted when error was called');
     logger.warn('warn message');
     expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when warn was called');
     logger.info('info message');
     expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when info was called');
     logger.debug('debug message');
-    expect(stdoutWriteSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
+    expect(stderrWriteSpy.called).to.equal(false, 'No logs should have been emitted when debug was called');
   });
 
   it('all logs should be emitted when when logLevel is VERBOSE', () => {
     logger = new Logger('LogName', LogLevel.VERBOSE);
     logger.error('error message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
     logger.debug('debug message');
-    expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
+    expect(stderrWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
   });
 
   it('all logs should be emitted when when logLevel is DEBUG', () => {
     logger = new Logger('LogName', LogLevel.DEBUG);
 
     logger.error('error message');
-    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stderrWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [ERROR] LogName - error message\r\n');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
 
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
-    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.args[0][0]).to.equal('[1984-05-07 03:09:05.008] [WARN] LogName - warn message\r\n');
 
     logger.info('info message');
-    expect(stdoutWriteSpy.args[2][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n');
-    expect(stdoutWriteSpy.callCount).to.equal(3, 'All logs should have been emitted');
+    expect(stdoutWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [INFO] LogName - info message\r\n');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
 
     logger.debug('debug message');
-    expect(stdoutWriteSpy.args[3][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n');
-    expect(stdoutWriteSpy.callCount).to.equal(4, 'All logs should have been emitted');
+    expect(stderrWriteSpy.args[1][0]).to.equal('[1984-05-07 03:09:05.008] [DEBUG] LogName - debug message\r\n');
+    expect(stderrWriteSpy.callCount).to.equal(2, 'All logs should have been emitted');
   });
 
   it('only error level logs should be emitted when when logLevel is ERROR', () => {
     logger = new Logger('LogName', LogLevel.ERROR);
     logger.error('error message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(0, 'only error level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(0, 'only error level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error level logs should be emitted');
   });
 
   it('only error and warn level logs should be emitted when when logLevel is WARN', () => {
     logger = new Logger('LogName', LogLevel.WARN);
     logger.error('error message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error and warn level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error and warn level logs should be emitted');
   });
 
   it('only error, warn, and info level logs should be emitted when when logLevel is INFO', () => {
     logger = new Logger('LogName', LogLevel.INFO);
     logger.error('error message');
-    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.warn('warn message');
-    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
     logger.info('info message');
-    expect(stdoutWriteSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+    expect(stdoutWriteSpy.callCount).to.equal(2, 'only error, warn, and info level logs should be emitted');
     logger.debug('debug message');
-    expect(stdoutWriteSpy.callCount).to.equal(3, 'only error, warn, and info level logs should be emitted');
+    expect(stderrWriteSpy.callCount).to.equal(1, 'only error, warn, and info level logs should be emitted');
   });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,6 @@
     ],
     "no-trailing-whitespace": true,
     "no-debugger": true,
-    "no-console": true,
     "no-unused-variable": true
   }
 }


### PR DESCRIPTION
@rjdavis3  This PR removes the Winston dependency. There is another branch - **feature/proof-that-logging-did-not-change** with the only change being that the Logger spec is a verbatim copy of what is on this branch - **feature/removing-winston**. It proves out that the current logging with Winston does not change with the updates from this branch.