### PR TITLE
Add ChannelApe use cases to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 Common logger used by all [ChannelApe](https://www.channelape.com) TypeScript and JavaScript projects.
 
 [![Build Status](https://travis-ci.org/ChannelApe/channelape-typescript-logger.svg?branch=master)](https://travis-ci.org/ChannelApe/channelape-typescript-logger)  [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=channelape-typescript-logger&metric=alert_status)](https://sonarcloud.io/dashboard?id=channelape-typescript-logger) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=channelape-typescript-logger&metric=coverage)](https://sonarcloud.io/dashboard?id=channelape-typescript-logger)
+
+
+
+## Use Cases
+
+Common Platform & SDK Use Cases:
+* [3pl companies](https://www.channelape.com/list/top-100-us-and-global-third-party-logistics-providers-3pl-2019/)
+* [3pl providers](https://www.channelape.com/list/top-100-us-and-global-third-party-logistics-providers-3pl-2019/)
+* [3pl services](https://www.channelape.com/list/top-100-us-and-global-third-party-logistics-providers-3pl-2019/)


### PR DESCRIPTION
Per request, I've added use cases to help users find us.